### PR TITLE
mcookbook: bump to fix failed maven-resources-plugin

### DIFF
--- a/mcookbook-content/pom.xml
+++ b/mcookbook-content/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.7</version>
         <configuration>
           <escapeString>\</escapeString>
           <encoding>UTF-8</encoding>

--- a/mcookbook-html/pom.xml
+++ b/mcookbook-html/pom.xml
@@ -33,7 +33,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.7</version>
         <configuration>
           <escapeString>\</escapeString>
           <encoding>UTF-8</encoding>

--- a/mcookbook-pdf/pom.xml
+++ b/mcookbook-pdf/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.7</version>
         <configuration>
           <escapeString>\</escapeString>
           <encoding>UTF-8</encoding>


### PR DESCRIPTION
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Maven Cookbook Content 0.5-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.3:resources (default-resources) @ mcookbook-content ---
[WARNING] The POM for org.apache.maven.shared:maven-filtering:jar:1.0-beta-2 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] Error injecting: org.apache.maven.shared.filtering.DefaultMavenFileFilter
java.lang.NoClassDefFoundError: org/codehaus/plexus/interpolation/ValueSource
        at java.lang.Class.getDeclaredConstructors0(Native Method)
        at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
        at java.lang.Class.getDeclaredConstructors(Class.java:2020)
        at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
        at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:99)
        at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:653)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:863)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:790)
        at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:278)
        at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:210)
        at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:986)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1019)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:982)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at org.eclipse.sisu.plexus.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:133)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1047)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:260)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:252)
        at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:459)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:97)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:317)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:152)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.interpolation.ValueSource
        at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:235)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
        ... 124 more
[WARNING] Error injecting: org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering
java.lang.NoClassDefFoundError: org/codehaus/plexus/interpolation/ValueSource
        at java.lang.Class.getDeclaredConstructors0(Native Method)
        at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
        at java.lang.Class.getDeclaredConstructors(Class.java:2020)
        at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
        at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:99)
        at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:653)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:863)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:790)
        at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:278)
        at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:210)
        at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:986)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1019)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:982)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at org.eclipse.sisu.plexus.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:133)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1047)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:260)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:252)
        at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:459)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:97)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:317)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:152)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.interpolation.ValueSource
        at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:235)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
        ... 124 more
[WARNING] Error injecting: org.apache.maven.plugin.resources.ResourcesMojo
java.lang.NoClassDefFoundError: org/codehaus/plexus/interpolation/ValueSource
        at java.lang.Class.getDeclaredConstructors0(Native Method)
        at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
        at java.lang.Class.getDeclaredConstructors(Class.java:2020)
        at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
        at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:99)
        at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:653)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:863)
        at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:790)
        at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:278)
        at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:210)
        at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:986)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1019)
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:982)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.eclipse.sisu.plexus.PlexusRequirements$RequirementProvider.get(PlexusRequirements.java:250)
        at org.eclipse.sisu.plexus.ProvidedPropertyBinding.injectProperty(ProvidedPropertyBinding.java:48)
        at org.eclipse.sisu.bean.BeanInjector.injectMembers(BeanInjector.java:52)
        at com.google.inject.internal.MembersInjectorImpl.injectMembers(MembersInjectorImpl.java:128)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:118)
        at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
        at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:92)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:116)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:269)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1054)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
        at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
        at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
        at org.eclipse.sisu.plexus.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:133)
        at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
        at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1047)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
        at com.google.inject.Scopes$1$1.get(Scopes.java:59)
        at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
        at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:260)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:252)
        at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:459)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:97)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:317)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:152)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.interpolation.ValueSource
        at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:235)
        at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
        ... 124 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.617s
[INFO] Finished at: Fri Mar 13 14:27:13 CET 2015
[INFO] Final Memory: 16M/491M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:2.3:resources (default-resources) on project mcookbook-content: Execution default-resources of goal org.apache.maven.plugins:maven-resources-plugin:2.3:resources failed: A required class was missing while executing org.apache.maven.plugins:maven-resources-plugin:2.3:resources: org/codehaus/plexus/interpolation/ValueSource
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-resources-plugin:2.3
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/rathgeb/.m2/repository/org/apache/maven/plugins/maven-resources-plugin/2.3/maven-resources-plugin-2.3.jar
[ERROR] urls[1] = file:/home/rathgeb/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[2] = file:/home/rathgeb/.m2/repository/org/codehaus/plexus/plexus-utils/1.5.6/plexus-utils-1.5.6.jar
[ERROR] urls[3] = file:/home/rathgeb/.m2/repository/org/apache/maven/shared/maven-filtering/1.0-beta-2/maven-filtering-1.0-beta-2.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[project>org.sonatype.mcookbook:mcookbook-content:0.5-SNAPSHOT, parent: ClassRealm[maven.api, parent: null]]]
[ERROR]
[ERROR] -----------------------------------------------------: org.codehaus.plexus.interpolation.ValueSource
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException

Signed-off-by: Markus Rathgeb maggu2810@gmail.com
